### PR TITLE
Remove libfreetype2, which should have been omitted and broke nightly

### DIFF
--- a/orglog-config.py
+++ b/orglog-config.py
@@ -1,7 +1,8 @@
 org = "servo"
 
 ignore_repos = ["skia", "skia-snapshots", "cairo", "libpng", "libcss",
-                "libhubbub", "libparserutils", "libwapcaplet", "pixman"]
+                "libhubbub", "libparserutils", "libwapcaplet", "pixman",
+                "libfreetype2"]
 count_forks = ["glutin","rust-openssl"]
 
 


### PR DESCRIPTION
Fixes https://github.com/servo/servo-org-stats/issues/3.

The problem is that libfreetype3 had a commit with some text in its message that was not valid utf8 and was breaking the processing scripts.

r? @edunham 
